### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linter


### PR DESCRIPTION
Potential fix for [https://github.com/dieperid/bucket-adapter/security/code-scanning/1](https://github.com/dieperid/bucket-adapter/security/code-scanning/1)

In general, this should be fixed by explicitly defining the minimal required `GITHUB_TOKEN` permissions using a `permissions` block, either at the workflow root (applies to all jobs) or per job. Since all three jobs here only need to read repository contents (for `actions/checkout` and running Maven locally), a single root‑level `permissions: contents: read` is sufficient.

Concretely, edit `.github/workflows/ci.yml` to add a `permissions` block near the top of the workflow, between the `on:` section and the `jobs:` section. This block should set `contents: read`. No other changes to steps or jobs are needed, and no imports or external definitions are required because this is pure GitHub Actions YAML configuration. The new block will ensure that `GITHUB_TOKEN` is restricted to read‑only access to repository contents for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
