### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/example/bucketadapter/adapter/impl/GcpAdapterImpl.java
+++ b/src/main/java/com/example/bucketadapter/adapter/impl/GcpAdapterImpl.java
@@ -47,19 +47,55 @@ public class GcpAdapterImpl implements BucketAdapter {
         this.bucket = bucket;
     }
 
+    /**
+     * Resolves and validates a local filesystem path provided by the caller.
+     * The resulting path is constrained to lie within a dedicated base directory,
+     * preventing directory traversal and access to unexpected locations.
+     *
+     * @param localSrc the user-provided local path
+     * @return a normalized, absolute path within the allowed base directory
+     * @throws InvalidBucketPathException if the path is invalid or outside the base directory
+     */
+    private Path resolveAndValidateLocalPath(final String localSrc) {
+        if (localSrc == null || localSrc.isBlank()) {
+            throw new InvalidBucketPathException("Local path must not be empty");
+        }
+
+        // Define a base directory for all local file operations.
+        // This can be adjusted or externalized as needed.
+        Path baseDir = Paths.get(".").toAbsolutePath().normalize();
+
+        // Disallow absolute paths directly provided by the caller to avoid
+        // bypassing the base directory restriction.
+        Path userPath = Paths.get(localSrc);
+        if (userPath.isAbsolute()) {
+            throw new InvalidBucketPathException("Absolute local paths are not allowed");
+        }
+
+        Path resolvedPath = baseDir.resolve(userPath).normalize();
+
+        // Ensure the resolved path is still within the base directory.
+        if (!resolvedPath.startsWith(baseDir)) {
+            throw new InvalidBucketPathException("Local path is outside the allowed directory");
+        }
+
+        return resolvedPath;
+    }
+
     @Override
     public void upload(final String localSrc, final String remoteSrc) {
         try {
-            File file = new File(localSrc);
+            Path resolvedPath = resolveAndValidateLocalPath(localSrc);
+            File file = resolvedPath.toFile();
             if (!file.exists() || !file.isFile()) {
                 throw new InvalidBucketPathException(
-                        "Local file does not exist: " + localSrc);
+                        "Local file does not exist: " + resolvedPath);
             }
 
             BlobId blobId = BlobId.of(bucket, remoteSrc);
             BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
-            storage.create(blobInfo, java.nio.file.Files.readAllBytes(file.toPath()));
+            storage.create(blobInfo, java.nio.file.Files.readAllBytes(resolvedPath));
 
         } catch (Exception e) {
             throw new BucketOperationException(
@@ -75,7 +111,13 @@ public class GcpAdapterImpl implements BucketAdapter {
                 throw new BucketObjectNotFoundException(remoteSrc);
             }
 
-            blob.downloadTo(Path.of(localSrc));
+            Path targetPath = resolveAndValidateLocalPath(localSrc);
+            Path parent = targetPath.getParent();
+            if (parent != null && !Files.exists(parent)) {
+                Files.createDirectories(parent);
+            }
+            blob.downloadTo(targetPath);
+
 
         } catch (Exception e) {
             throw new BucketOperationException(


### PR DESCRIPTION
Potential fix for [https://github.com/dieperid/bucket-adapter/security/code-scanning/4](https://github.com/dieperid/bucket-adapter/security/code-scanning/4)

In general, the fix is to validate and constrain the user-supplied paths (`localPath` / `localSrc`) before using them to create `File` or `Path` instances. A common pattern is to define a single, safe base directory on the server and ensure that any requested path, after resolution and normalization, still lies within that directory. This prevents directory traversal (`..`), absolute paths, and writing/reading outside the intended area. Additionally, rejecting inputs containing obviously dangerous constructs (`..`, path separators when a single filename is expected) is helpful.

The best way to fix this code with minimal behavior change is:

1. In `GcpAdapterImpl`, introduce a private helper method, e.g. `resolveAndValidateLocalPath(String localSrc)`, which:
   - Takes the provided `localSrc`.
   - Resolves it against a chosen base directory (for example, the process working directory or a configurable root like `Paths.get("data")`).
   - Normalizes the result.
   - Checks that the resulting path starts with the base directory; if not, throws `InvalidBucketPathException`.
   - Optionally rejects absolute `localSrc` inputs to enforce relative paths.
2. Use this helper in both `upload` and `download`:
   - In `upload`, replace `File file = new File(localSrc);` with something like:
     ```java
     Path resolvedPath = resolveAndValidateLocalPath(localSrc);
     File file = resolvedPath.toFile();
     ```
     and read bytes from `resolvedPath` rather than `file.toPath()` (or keep `file.toPath()` since they are equivalent).
   - In `download`, replace `blob.downloadTo(Path.of(localSrc));` with:
     ```java
     Path targetPath = resolveAndValidateLocalPath(localSrc);
     blob.downloadTo(targetPath);
     ```
3. Implement `resolveAndValidateLocalPath` inside `GcpAdapterImpl` using `java.nio.file.Path` and `Paths`. Since these imports already exist (`java.nio.file.Path`, `java.nio.file.Paths`, `java.nio.file.Files`), no new imports are needed. Use `Files.createDirectories` on the parent directory in `download` to ensure that intermediate directories exist if you want to keep current behavior (or slightly improve robustness) without widening access.

All changes are confined to `GcpAdapterImpl` (within the shown snippet), and no signatures in `BucketService` or `BucketController` need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
